### PR TITLE
Remove calls to JavaUtil.convertRubyToJava

### DIFF
--- a/src/zweikopf/core.clj
+++ b/src/zweikopf/core.clj
@@ -79,7 +79,24 @@
                  (persistent! acc))))
 
   RubyString
-  (clojurize [this] (JavaUtil/convertRubyToJava this))
+  (clojurize [this]
+    (.decodeString this))
+
+  org.jruby.RubyNil
+  (clojurize  [_]
+    nil)
+
+  org.jruby.RubyFixnum
+  (clojurize  [this]
+    (.getLongValue this))
+
+  org.jruby.RubyFloat
+  (clojurize  [this]
+    (.getDoubleValue this))
+
+  org.jruby.RubyBoolean
+  (clojurize  [this]
+    (.isTrue this))
 
   org.jruby.RubyTime
   (clojurize [this]
@@ -89,8 +106,7 @@
   (clojurize [this]
     (condp #(call-ruby %2 respond_to? %1) this
       "to_hash" (clojurize (call-ruby this to_hash))
-      "to_time" (clojurize (call-ruby this to_time))
-      (JavaUtil/convertRubyToJava this)))
+      "to_time" (clojurize (call-ruby this to_time))))
 
   java.lang.Object
   (clojurize [this] this))


### PR DESCRIPTION
JavaUtil.convertRubyToJava is [deprecated](http://jruby.org/apidocs/org/jruby/javasupport/JavaUtil.html#convertRubyToJava%28org.jruby.runtime.builtin.IRubyObject%29). This commit replaces it
with calls to more specific methods which perform necessary conversions.
