### PR TITLE
Instead of #to_time, clojurize using #strftime

### DIFF
--- a/src/zweikopf/core.clj
+++ b/src/zweikopf/core.clj
@@ -106,7 +106,11 @@
   (clojurize [this]
     (condp #(call-ruby %2 respond_to? %1) this
       "to_hash" (clojurize (call-ruby this to_hash))
-      "to_time" (clojurize (call-ruby this to_time))))
+      "strftime" (-> this
+                     (call-ruby strftime "%s")
+                     (call-ruby to_i)
+                     (* 1000)
+                     java.util.Date.)))
 
   java.lang.Object
   (clojurize [this] this))


### PR DESCRIPTION
This should work better with other classes representing time/date.
