### PR TITLE
Rubyize lazy seqs

### DIFF
--- a/src/zweikopf/multi.clj
+++ b/src/zweikopf/multi.clj
@@ -122,17 +122,7 @@
     (doto (RubyHash. (runtime ruby))
       (.putAll (apply-to-keys-and-values this #(rubyize % ruby)))))
 
-  clojure.lang.PersistentArrayMap
-  (rubyize [this ruby]
-    (doto (RubyHash. (runtime ruby))
-      (.putAll (apply-to-keys-and-values this #(rubyize % ruby)))))
-
-  clojure.lang.IPersistentVector
-  (rubyize [this ruby]
-    (doto (RubyArray/newArray (runtime ruby))
-      (.addAll (for [item this] (rubyize item ruby)))))
-
-  clojure.lang.IPersistentList
+  clojure.lang.Seqable
   (rubyize [this ruby]
     (doto (RubyArray/newArray (runtime ruby))
       (.addAll (for [item this] (rubyize item ruby)))))

--- a/test/zweikopf/core_test.clj
+++ b/test/zweikopf/core_test.clj
@@ -48,6 +48,9 @@
   (testing "Non-empty array"
     (is (= (ruby-eval "[1, :a, 'b']") (rubyize [1 :a "b"])) ))
 
+  (testing "Lazy seq"
+    (is (= (ruby-eval "[:a, :b, :c]") (rubyize (lazy-seq [:a :b :c])))))
+
   (testing "Deep array"
     (is (= (ruby-eval "[:a, [:c, :d], :e, :f]") (rubyize [:a [:c :d] :e :f])) ))
 


### PR DESCRIPTION
Apart from extending the Rubyize protocol for lazy seqs, remove some
redundant cases covered by existing ones.
